### PR TITLE
Add libabseil to host dependencies

### DIFF
--- a/.ci_support/linux_64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy2.0python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+libabseil:
+- '20240722'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy2.0python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+libabseil:
+- '20240722'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_numpy2.0python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+libabseil:
+- '20240722'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_numpy2python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+libabseil:
+- '20240722'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+libabseil:
+- '20240722'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+libabseil:
+- '20240722'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+libabseil:
+- '20240722'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_numpy2python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+libabseil:
+- '20240722'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_arm64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+libabseil:
+- '20240722'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+libabseil:
+- '20240722'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+libabseil:
+- '20240722'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_numpy2python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+libabseil:
+- '20240722'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/win_64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/win_64_numpy2.0python3.10.____cpython.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libabseil:
+- '20240722'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy2.0python3.11.____cpython.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libabseil:
+- '20240722'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/win_64_numpy2.0python3.12.____cpython.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libabseil:
+- '20240722'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/win_64_numpy2python3.13.____cp313.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libabseil:
+- '20240722'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 40d2450881b0953048d9b214db647c3cc48af60c2a645ec49969e7687e9c5d88
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310 or python_impl == 'pypy']
   script: python -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - pip
     - scikit-build-core
     - pybind11 >=2.10.0
+    - libabseil
     - s2geometry
     - s2geography >=0.2.0,<0.3
     - numpy


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Seems like this transitive dependency needs to be added in order to prevent linking issues when trying to import spherely (as I encountered when installing spherely in a new conda environment, after s2geometry and s2geography were rebuilt from the absl migration).

<!--
Please add any other relevant info below:
-->
